### PR TITLE
Enable template selection in browser builds

### DIFF
--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,11 @@
+export function isTauriEnvironment(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return Boolean((window as WindowWithTauri).__TAURI_INTERNALS__);
+}
+
+interface WindowWithTauri extends Window {
+  __TAURI_INTERNALS__?: unknown;
+}


### PR DESCRIPTION
## Summary
- add Tauri environment detection and browser directory picker fallback to the top bar actions
- extend the project context and template loader to read templates from File System Access handles
- disable desktop-only actions when running in the browser while keeping user feedback via logs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e113b42b708332b224737df96257ca