### PR TITLE
feat: add browser-styled preview with detachable floating window

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -208,6 +208,28 @@ main {
   justify-content: space-between;
   padding: 0.75rem 1rem;
   border-bottom: 1px solid #e2e8f0;
+  gap: 1rem;
+}
+
+.preview-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.preview-heading button {
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  color: #1e293b;
+  font-size: 0.8rem;
+  border-radius: 6px;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.preview-heading button:hover {
+  background: #e2e8f0;
 }
 
 .preview .modes {
@@ -237,18 +259,205 @@ main {
   background: #f8fafc;
 }
 
-.preview iframe {
+.preview iframe,
+.floating-window iframe {
   width: 100%;
   height: 100%;
   border: none;
   background: #fff;
 }
 
-.preview-mobile iframe {
+.preview-detached {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 0.75rem;
+  color: #475569;
+}
+
+.preview-detached button {
+  border: 1px solid #2563eb;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 6px;
+  padding: 0.35rem 0.85rem;
+}
+
+.browser-preview {
+  width: min(100%, 960px);
+  aspect-ratio: 16 / 10;
+  border-radius: 12px;
+  border: 1px solid #dbe3f4;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  background: #f1f5f9;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.browser-toolbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  padding: 0.65rem 1rem;
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+  gap: 1rem;
+}
+
+.browser-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.browser-buttons span {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.browser-buttons span:nth-child(1) {
+  background: #f87171;
+}
+
+.browser-buttons span:nth-child(2) {
+  background: #fbbf24;
+}
+
+.browser-buttons span:nth-child(3) {
+  background: #34d399;
+}
+
+.browser-address {
+  background: #e2e8f0;
+  border-radius: 999px;
+  padding: 0.35rem 1rem;
+  font-size: 0.85rem;
+  color: #475569;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browser-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.browser-actions span {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  background: #cbd5f5;
+}
+
+.browser-content {
+  flex: 1;
+  background: #fff;
+}
+
+.mobile-preview {
   width: 375px;
   height: 667px;
-  border-radius: 20px;
-  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.25);
+  border-radius: 32px;
+  padding: 1.25rem 0.75rem;
+  background: linear-gradient(180deg, #111827 0%, #1f2937 100%);
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mobile-notch {
+  align-self: center;
+  width: 160px;
+  height: 24px;
+  border-radius: 0 0 16px 16px;
+  background: #0f172a;
+}
+
+.mobile-preview iframe {
+  flex: 1;
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
+}
+
+.floating-window-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 30;
+}
+
+.floating-window {
+  position: absolute;
+  width: 560px;
+  height: 640px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.25);
+  border: 1px solid #cbd5f5;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  resize: both;
+  pointer-events: auto;
+}
+
+.floating-window.dragging {
+  cursor: grabbing;
+  user-select: none;
+}
+
+.floating-window-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 0.9rem;
+  background: #1d4ed8;
+  color: #fff;
+  cursor: grab;
+}
+
+.floating-window-title button {
+  border: none;
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  font-size: 1.1rem;
+  line-height: 1;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.floating-window-title button:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.floating-window-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #f8fafc;
+}
+
+.floating-preview-controls {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.75rem 0.9rem 0;
+}
+
+.floating-preview-surface {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 0.9rem 1rem;
+  gap: 1rem;
 }
 
 .logs {

--- a/src/components/FloatingPreviewWindow.tsx
+++ b/src/components/FloatingPreviewWindow.tsx
@@ -1,0 +1,86 @@
+import { PropsWithChildren, useEffect, useMemo, useRef, useState } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { createPortal } from "react-dom";
+
+interface FloatingPreviewWindowProps {
+  title: string;
+  onClose: () => void;
+}
+
+export function FloatingPreviewWindow({ title, onClose, children }: PropsWithChildren<FloatingPreviewWindowProps>) {
+  const [position, setPosition] = useState({ x: 80, y: 80 });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragOffset = useRef({ x: 0, y: 0 });
+  const container = useMemo(() => document.createElement("div"), []);
+  const windowRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    document.body.appendChild(container);
+    return () => {
+      document.body.removeChild(container);
+    };
+  }, [container]);
+
+  useEffect(() => {
+    function handleMouseMove(event: MouseEvent) {
+      if (!isDragging) return;
+      const bounds = windowRef.current?.getBoundingClientRect();
+      const width = bounds?.width ?? 0;
+      const height = bounds?.height ?? 0;
+      const maxX = window.innerWidth - width;
+      const maxY = window.innerHeight - height;
+
+      const nextX = event.clientX - dragOffset.current.x;
+      const nextY = event.clientY - dragOffset.current.y;
+
+      setPosition({
+        x: Math.min(Math.max(0, nextX), Math.max(0, maxX)),
+        y: Math.min(Math.max(0, nextY), Math.max(0, maxY)),
+      });
+    }
+
+    function handleMouseUp() {
+      setIsDragging(false);
+    }
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging]);
+
+  function handlePointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.button !== 0) return;
+    const rect = windowRef.current?.getBoundingClientRect();
+    if (!rect) return;
+
+    event.preventDefault();
+    setIsDragging(true);
+    dragOffset.current = {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  }
+
+  return createPortal(
+    <div className="floating-window-overlay" role="presentation">
+      <div
+        ref={windowRef}
+        className={`floating-window ${isDragging ? "dragging" : ""}`}
+        style={{ top: position.y, left: position.x }}
+      >
+        <header className="floating-window-title" onPointerDown={handlePointerDown}>
+          <span>{title}</span>
+          <button type="button" onClick={onClose} aria-label="Fechar preview">
+            ×
+          </button>
+        </header>
+        <div className="floating-window-content">{children}</div>
+      </div>
+    </div>,
+    container
+  );
+}

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { RenderedTemplate } from "@/core/template";
+import { FloatingPreviewWindow } from "./FloatingPreviewWindow";
 
 interface PreviewPanelProps {
   rendered: RenderedTemplate | null;
@@ -8,34 +9,118 @@ interface PreviewPanelProps {
 type ViewMode = "desktop" | "mobile";
 
 export function PreviewPanel({ rendered }: PreviewPanelProps) {
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [mode, setMode] = useState<ViewMode>("desktop");
+  const [isDetached, setIsDetached] = useState(false);
 
   const html = useMemo(() => buildPreviewHtml(rendered), [rendered]);
+
+  return (
+    <>
+      <aside className={`preview preview-${mode}`}>
+        <header>
+          <div className="preview-heading">
+            <h2>Preview</h2>
+            <button type="button" onClick={() => setIsDetached((current) => !current)}>
+              {isDetached ? "Recolocar" : "Destacar"}
+            </button>
+          </div>
+          <ModeSelector mode={mode} onChange={setMode} />
+        </header>
+        <div className="preview-surface">
+          {isDetached ? (
+            <div className="preview-detached" role="status">
+              <p>A pré-visualização está aberta em uma janela flutuante.</p>
+              <button type="button" onClick={() => setIsDetached(false)}>
+                Recolocar preview
+              </button>
+            </div>
+          ) : (
+            <PreviewViewport mode={mode} html={html} />
+          )}
+        </div>
+      </aside>
+
+      {isDetached && (
+        <FloatingPreviewWindow title="Preview" onClose={() => setIsDetached(false)}>
+          <div className="floating-preview-controls">
+            <ModeSelector mode={mode} onChange={setMode} />
+          </div>
+          <div className={`floating-preview-surface preview-${mode}`}>
+            <PreviewViewport mode={mode} html={html} />
+          </div>
+        </FloatingPreviewWindow>
+      )}
+    </>
+  );
+}
+
+interface ModeSelectorProps {
+  mode: ViewMode;
+  onChange: (mode: ViewMode) => void;
+}
+
+function ModeSelector({ mode, onChange }: ModeSelectorProps) {
+  return (
+    <div className="modes">
+      <button type="button" className={mode === "desktop" ? "active" : ""} onClick={() => onChange("desktop")}>
+        Desktop
+      </button>
+      <button type="button" className={mode === "mobile" ? "active" : ""} onClick={() => onChange("mobile")}>
+        Mobile
+      </button>
+    </div>
+  );
+}
+
+interface PreviewViewportProps {
+  mode: ViewMode;
+  html: string | undefined;
+}
+
+function PreviewViewport({ mode, html }: PreviewViewportProps) {
+  const iframeRef = useIframe(html);
+
+  if (mode === "desktop") {
+    return (
+      <div className="browser-preview">
+        <div className="browser-toolbar" aria-hidden="true">
+          <div className="browser-buttons" aria-hidden="true">
+            <span />
+            <span />
+            <span />
+          </div>
+          <div className="browser-address" aria-label="Endereço">
+            <span>https://preview.local</span>
+          </div>
+          <div className="browser-actions" aria-hidden="true">
+            <span />
+            <span />
+          </div>
+        </div>
+        <div className="browser-content">
+          <iframe ref={iframeRef} title="Preview" sandbox="allow-same-origin allow-forms allow-scripts" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mobile-preview">
+      <div className="mobile-notch" aria-hidden="true" />
+      <iframe ref={iframeRef} title="Preview" sandbox="allow-same-origin allow-forms allow-scripts" />
+    </div>
+  );
+}
+
+function useIframe(html: string | undefined) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
   useEffect(() => {
     if (!iframeRef.current) return;
     iframeRef.current.srcdoc = html ?? "<p>Pré-visualização indisponível</p>";
   }, [html]);
 
-  return (
-    <aside className={`preview preview-${mode}`}>
-      <header>
-        <h2>Preview</h2>
-        <div className="modes">
-          <button className={mode === "desktop" ? "active" : ""} onClick={() => setMode("desktop")}>
-            Desktop
-          </button>
-          <button className={mode === "mobile" ? "active" : ""} onClick={() => setMode("mobile")}>
-            Mobile
-          </button>
-        </div>
-      </header>
-      <div className="preview-surface">
-        <iframe ref={iframeRef} title="Preview" sandbox="allow-same-origin allow-forms allow-scripts" />
-      </div>
-    </aside>
-  );
+  return iframeRef;
 }
 
 function buildPreviewHtml(rendered: RenderedTemplate | null): string | undefined {


### PR DESCRIPTION
## Summary
- redesign the desktop preview area with a browser-style frame and refreshed mobile mock device
- add controls to detach the preview into a draggable, resizable floating window with reattach support
- share viewport mode toggles between the sidebar panel and floating window while showing placeholder guidance when detached

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1242b7c208332bee9e474a03ae700