### PR TITLE
feat: open preview fullscreen when detached

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -401,6 +401,14 @@ main {
   z-index: 30;
 }
 
+.floating-window-overlay-fullscreen {
+  pointer-events: auto;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+}
+
 .floating-window {
   position: absolute;
   width: 560px;
@@ -415,6 +423,17 @@ main {
   flex-direction: column;
   overflow: hidden;
   pointer-events: auto;
+}
+
+.floating-window-fullscreen {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
 }
 
 .floating-window.dragging {
@@ -460,6 +479,19 @@ main {
   flex-direction: column;
   background: #f8fafc;
   position: relative;
+}
+
+.floating-window-content-fullscreen {
+  padding: 1.5rem;
+}
+
+.floating-window-content-fullscreen .floating-preview-controls {
+  padding: 0;
+  justify-content: flex-end;
+}
+
+.floating-window-content-fullscreen .floating-preview-surface {
+  padding: 1.5rem 0 0;
 }
 
 .floating-preview-controls {

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -41,7 +41,7 @@ export function PreviewPanel({ rendered }: PreviewPanelProps) {
       </aside>
 
       {isDetached && (
-        <FloatingPreviewWindow title="Preview" onClose={() => setIsDetached(false)}>
+        <FloatingPreviewWindow title="Preview" variant="fullscreen" onClose={() => setIsDetached(false)}>
           <div className="floating-preview-controls">
             <ModeSelector mode={mode} onChange={setMode} />
           </div>


### PR DESCRIPTION
## Summary
- add a fullscreen variant to the floating preview window component
- style the fullscreen preview overlay to cover the entire viewport when detached
- update the preview panel to use the fullscreen overlay when highlighting the preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e13778a16083329b2a0264ab70dbd7