### PR TITLE
Ensure generic sections create file-specific tabs

### DIFF
--- a/src/services/__tests__/autoTemplateGenerator.test.ts
+++ b/src/services/__tests__/autoTemplateGenerator.test.ts
@@ -36,6 +36,43 @@ describe("autoTemplateGenerator navigation deduplication", () => {
     expect(navigationGroups).toHaveLength(1);
     expect(navigationGroups[0]?.fields.length).toBeGreaterThan(0);
   });
+
+  it("creates separate tabs for generic section labels across different files", () => {
+    const buildHtml = (text: string) => `<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <title>Landing</title>
+  </head>
+  <body>
+    <section>
+      <p>${text}</p>
+    </section>
+  </body>
+</html>`;
+
+    const files: TemplateFile[] = [
+      { path: "primeiro.html", contents: buildHtml("Primeiro arquivo") },
+      { path: "segundo.html", contents: buildHtml("Segundo arquivo") },
+    ];
+
+    const result = autoGenerateTemplate("Landing", files);
+
+    const tabIds = result.schema.tabs.map((tab) => tab.id);
+    expect(tabIds).toContain("auto-se_o_1-arquivo_primeiro_html");
+    expect(tabIds).toContain("auto-se_o_1-arquivo_segundo_html");
+
+    const genericTabs = result.schema.tabs.filter((tab) =>
+      tab.id.startsWith("auto-se_o_1-arquivo_"),
+    );
+    expect(genericTabs).toHaveLength(2);
+    expect(genericTabs.map((tab) => tab.label)).toEqual(
+      expect.arrayContaining([
+        "Seção 1 · Arquivo: primeiro.html",
+        "Seção 1 · Arquivo: segundo.html",
+      ]),
+    );
+  });
 });
 
 describe("autoTemplateGenerator color extraction", () => {


### PR DESCRIPTION
## Summary
- pass a friendly file label into the section tab builder and treat generic section labels as file-specific when categorizing tabs
- append file-derived suffixes to auto-generated tab ids and labels to avoid merging tabs from different files
- cover the new behavior with a unit test that ensures two HTML files with generic sections yield separate tabs

## Testing
- npm run test -- --run src/services/__tests__/autoTemplateGenerator.test.ts *(fails: existing navigation/color/form expectations in the suite)*
- npx vitest run src/services/__tests__/autoTemplateGenerator.test.ts -t "creates separate tabs for generic section labels across different files"

------
https://chatgpt.com/codex/tasks/task_e_68e17b7768d48332aa38a112c3ff919a