### PR TITLE
Sort auto style groups alphabetically

### DIFF
--- a/src/services/autoTemplateGenerator.ts
+++ b/src/services/autoTemplateGenerator.ts
@@ -272,6 +272,7 @@ export function autoGenerateTemplate(
   ];
 
   if (styleGroups.length > 0) {
+    styleGroups.sort((a, b) => a.label.localeCompare(b.label, "pt-BR"));
     tabs.push({
       id: "auto-styles",
       label: "Estilos visuais",


### PR DESCRIPTION
## Summary
- sort the collected auto style groups by their label using the pt-BR locale before creating the styles tab

## Testing
- `npm test -- --run` *(fails: existing autoTemplateGenerator tests expect flattened config keys and navigation deduplication that currently do not occur)*

------
https://chatgpt.com/codex/tasks/task_e_68e17db1e96c8332a77f8b2cdd60a83c