### PR TITLE
Humanize auto template file labels

### DIFF
--- a/src/services/__tests__/autoTemplateGenerator.test.ts
+++ b/src/services/__tests__/autoTemplateGenerator.test.ts
@@ -59,17 +59,17 @@ describe("autoTemplateGenerator navigation deduplication", () => {
     const result = autoGenerateTemplate("Landing", files);
 
     const tabIds = result.schema.tabs.map((tab) => tab.id);
-    expect(tabIds).toContain("auto-se_o_1-arquivo_primeiro_html");
-    expect(tabIds).toContain("auto-se_o_1-arquivo_segundo_html");
+    expect(tabIds).toContain("auto-se_o_1-primeiro");
+    expect(tabIds).toContain("auto-se_o_1-segundo");
 
     const genericTabs = result.schema.tabs.filter((tab) =>
-      tab.id.startsWith("auto-se_o_1-arquivo_"),
+      tab.id.startsWith("auto-se_o_1-"),
     );
     expect(genericTabs).toHaveLength(2);
     expect(genericTabs.map((tab) => tab.label)).toEqual(
       expect.arrayContaining([
-        "Seção 1 · Arquivo: primeiro.html",
-        "Seção 1 · Arquivo: segundo.html",
+        "Seção 1 · Primeiro",
+        "Seção 1 · Segundo",
       ]),
     );
   });

--- a/src/services/autoTemplateGenerator.ts
+++ b/src/services/autoTemplateGenerator.ts
@@ -480,7 +480,7 @@ function transformCssFile(
   const styleGroup: SchemaGroup = {
     id: groupId,
     label: `${displayLabelForFile(file.path)} · Estilos`,
-    description: "Cores, gradientes e imagens detectadas automaticamente no CSS.",
+    description: `Cores, gradientes e imagens detectadas automaticamente no CSS do arquivo ${file.path}.`,
     fields: styleFields,
   };
 
@@ -1202,7 +1202,7 @@ function transformHtmlFile(
         {
           id: `${baseKey}-seo`,
           label: `${displayLabelForFile(file.path)} · SEO`,
-          description: "Metadados extraídos automaticamente.",
+          description: `Metadados extraídos automaticamente do arquivo ${file.path}.`,
           fields: seoFields,
         },
       ]
@@ -1213,7 +1213,7 @@ function transformHtmlFile(
         {
           id: `${schemaIdPrefix(`${baseKey}.inline-styles`)}-palette`,
           label: `${displayLabelForFile(file.path)} · Estilos`,
-          description: "Cores, gradientes e imagens detectadas automaticamente no HTML.",
+          description: `Cores, gradientes e imagens detectadas automaticamente no HTML do arquivo ${file.path}.`,
           fields: inlineStyleFields,
         },
       ]
@@ -2220,7 +2220,7 @@ function fallbackGeneration(templateLabel: string, originalFiles: TemplateFile[]
     groups.push({
       id: `auto-${sanitizeKey(file.path)}-raw`,
       label: displayLabelForFile(file.path),
-      description: "Edição direta do conteúdo HTML (fallback)",
+      description: `Edição direta do conteúdo HTML (fallback). Arquivo original: ${file.path}.`,
       fields: [
         {
           key: baseKey,
@@ -2288,7 +2288,11 @@ function deriveTemplateName(label: string): string {
 }
 
 function displayLabelForFile(path: string): string {
-  return `Arquivo: ${path}`;
+  const segments = path.split(/[\\/]/).filter(Boolean);
+  const lastSegment = segments.pop() ?? path;
+  const withoutExtension = lastSegment.replace(/\.[^/.]+$/, "");
+  const formatted = formatLabel(withoutExtension);
+  return formatted || "Arquivo";
 }
 
 function sanitizeFileSuffix(value: string): string {


### PR DESCRIPTION
## Summary
- format file-derived labels using the file name without extension
- move file path information into SEO, style, and fallback raw group descriptions
- update auto template generator tests to expect the new humanized labels

## Testing
- npx vitest run src/services/__tests__/autoTemplateGenerator.test.ts (fails: existing expectations)


------
https://chatgpt.com/codex/tasks/task_e_68e180bba1f4833281d01ee92f20a423